### PR TITLE
use iptables v1.8.10 in vm

### DIFF
--- a/vm/overlay.nix
+++ b/vm/overlay.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  ...
+}:
+
+{
+  nixpkgs.overlays = [
+    (self: super: {
+      iptables = super.iptables.overrideAttrs (oldAttrs: rec {
+	version = "1.8.10";
+        src = pkgs.fetchurl {
+	  url = "https://www.netfilter.org/projects/iptables/files/iptables-${version}.tar.xz";
+          sha256 = "sha256-XMJVwYk1bjF9BwdVzpNx62Oht4PDRJj7jDAmTzzFnJw=";
+        };
+      });
+    })
+  ];
+
+}

--- a/vm/vm.nix
+++ b/vm/vm.nix
@@ -25,6 +25,7 @@ in
     (modulesPath + "/profiles/qemu-guest.nix")
     ./cirrus-runner.nix
     ./nix-store-isolation.nix
+    ./overlay.nix
   ];
 
   virtualisation = {


### PR DESCRIPTION
As per https://github.com/0xB10C/bitcoin-core-cirrus-runner-infra/issues/3#issuecomment-2733530990, pin iptables to 1.8.10 in the VM. This works around a problem with iptables v1.8.11.